### PR TITLE
Close #1: Visualise hotkeys for zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This script allows you to remove this restriction with maximum customisation.
 To activate it, copy [zone-bindings.lua] to your `hack/scripts` directory
 and add the desired key bindings to `dfhack-config/init/dfhack.init`.
 
+#### Recommended settings
+
 In the following configuration example,
 zones are sorted and grouped just like they appear in the game
 for readability:
@@ -53,10 +55,78 @@ keybinding add Shift-L@dwarfmode/Zone "zone-bindings clay"
 Read [docs/zone-bindings.rst]
 if you want to understand the script usage a bit more.
 
+### gui/visible-hotkeys
+
+Zones, unlike buildings, do not have key bindings in the vanilla version of the game.
+When you are going to create multiple temples or guilds, using mouse becomes annoying.
+This script allows you to remove this restriction with maximum customisation.
+
+To activate it, copy [gui/visible-hotkeys.lua] to your `hack/scripts/gui` directory
+and enable the script and overlay by adding the following lines to your `dfhack-config/init/dfhack.init`:
+```
+# hack/scripts/gui
+
+enable gui/visible-hotkeys
+overlay enable gui/visible-hotkeys.zone-overlay
+```
+
+#### Default key bindings
+
+The following hotkeys are available by default in zone selection menu
+once you enable the script:
+
+- Meeting Area: `m`
+- Bedroom: `b`
+- Dining Hall: `h`
+- Pen/Pasture: `p`
+- Pit/Pond: `P`
+- Water Source: `r`
+- Dungeon: `n`
+- Fishing: `f`
+- Sand: `N`
+- Office: `o`
+- Dormitory: `y`
+- Barracks: `B`
+- Archery Range: `Y`
+- Garbage Dump: `g`
+- Animal Training: `l`
+- Tomb: `T`
+- Gather Fruit: `F`
+- Clay: `L`
+
+Lowercase letters mean just pressing the key,
+and uppercase letters mean holding the `Shift` button and pressing the key.
+
+#### Custom key bindings
+
+You can create your own assignments in `dfhack-config/init/onLoad.init`.
+You must use this file to avoid known issues with incorrect keys displayed in the widget.
+If your new key binding conflicts with any other hotkey managed by the script,
+it will be unassigned first.
+
+For example, the following code assigns `Shift-A` for painting a meeting area,
+`O` (without `Shift`) for painting tomb,
+and removes bindings for bedroom zone:
+```
+# dfhack-config/init/onLoad.init
+
+:lua reqscript('gui/visible-hotkeys').add('Meeting Area', 'A')
+:lua reqscript('gui/visible-hotkeys').add('Tomb', 'o')
+:lua reqscript('gui/visible-hotkeys').clear('Bedroom')
+```
+
+By default, `o` is used for office,
+so these commands will also remove the key bindings for office.
+
+Read [docs/gui/visible-hotkeys.rst]
+if you want to understand the script usage a bit more.
+
 [DFHack]: https://github.com/DFHack/dfhack/
 [dfhack-steam]: https://store.steampowered.com/app/2346660/DFHack__Dwarf_Fortress_Modding_Engine/
 [df]: https://www.bay12games.com/dwarves/
 [df-steam]: https://store.steampowered.com/app/975370
 [df-itch]: https://kitfoxgames.itch.io/dwarf-fortress
+[docs/gui/visible-hotkeys.rst]: docs/gui/visible-hotkeys.rst
 [docs/zone-bindings.rst]: docs/zone-bindings.rst
+[gui/visible-hotkeys.lua]: gui/visible-hotkeys.lua
 [zone-bindings.lua]: zone-bindings.lua

--- a/docs/gui/visible-hotkeys.rst
+++ b/docs/gui/visible-hotkeys.rst
@@ -1,5 +1,5 @@
-visible-hotkeys
-=============
+gui/visible-hotkeys
+===================
 
 .. dfhack-tool::
     :summary: Module for assigning and visualising zone key bindings.

--- a/docs/gui/visible-hotkeys.rst
+++ b/docs/gui/visible-hotkeys.rst
@@ -20,12 +20,14 @@ Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration
 to enable hotkeys in zone selection window:
 
 ::
+
     enable gui/visible-hotkeys
 
 Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file
 to display the hotkeys assigned via this script in zone selection window:
 
 ::
+
     overlay enable gui/visible-hotkeys.zone-overlay
 
 Add the following lines to your ``dfhack-config/init/onLoad.init`` configuration file
@@ -107,11 +109,12 @@ Known issues
 ------------
 
 The widget draws the default key bindings in the following cases:
-- The bindings are specified in ``dfhack-config/init/dfhack.init`` rather then ``dfhack-config/init/onLoad.init``
+
+* The bindings are specified in ``dfhack-config/init/dfhack.init`` rather then ``dfhack-config/init/onLoad.init``
   and the user reloads a saved game without exiting the Dwarf Fortress application.
-- The bindings are specified during the game (in the game console, ``Ctrl-Shift-P``).
+* The bindings are specified during the game (in the game console, ``Ctrl-Shift-P``).
 
 Workaround:
 
 Set up the key bindings for this script only in ``dfhack-config/init/onLoad.init``.
-Do not expect the overlay to display the correct information after modifying the bindings from DFHack console.
+Do not expect the overlay to display the correct information after modifying the bindings from the DFHack console.

--- a/docs/gui/visible-hotkeys.rst
+++ b/docs/gui/visible-hotkeys.rst
@@ -1,0 +1,117 @@
+visible-hotkeys
+=============
+
+.. dfhack-tool::
+    :summary: Module for assigning and visualising zone key bindings.
+    :tags: fort productivity buildings
+
+By default, users cannot assign key bindings to zones.
+This script allows creating custom key bindings and shows them in the zone choice menu.
+
+Usage
+-----
+
+Be careful and use the proper configuration files.
+You should enable the script and widget in ``dfhack.init``
+while key bindings reassignment should take place in ``onLoad.init``.
+This issue is due to be investigated.
+
+Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file
+to enable hotkeys in zone selection window:
+
+::
+    enable gui/visible-hotkeys
+
+Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file
+to display the hotkeys assigned via this script in zone selection window:
+
+::
+    overlay enable gui/visible-hotkeys.zone-overlay
+
+Add the following lines to your ``dfhack-config/init/onLoad.init`` configuration file
+to modify key bindings.
+The key must be a single lowercase or uppercase letter.
+An uppercase letter means using the ``Shift`` key,
+while a lowercase letter means pressing the key corresponding to the letter.
+The quotes are necessary.
+For multiple assignments, you must repeat the command with different zone titles.
+
+::
+
+    :lua reqscript('gui/visible-hotkeys').add('<zone title>', '<key>')
+
+Add the following lines to your ``dfhack-config/init/onLoad.init`` configuration file
+to remove key binding for the zone.
+It is safe to clear when no bindings are assigned.
+
+::
+
+    :lua reqscript('gui/visible-hotkeys').clear('<zone title>')
+
+Default hotkeys
+----------------
+
+The following hotkeys are available by default in zone selection menu
+once you enable the script:
+
+- Meeting Area: ``m``
+- Bedroom: ``b``
+- Dining Hall: ``h``
+- Pen/Pasture: ``p``
+- Pit/Pond: ``P``
+- Water Source: ``r``
+- Dungeon: ``n``
+- Fishing: ``f``
+- Sand: ``N``
+- Office: ``o``
+- Dormitory: ``y``
+- Barracks: ``B``
+- Archery Range: ``Y``
+- Garbage Dump: ``g``
+- Animal Training: ``l``
+- Tomb: ``T``
+- Gather Fruit: ``F``
+- Clay: ``L``
+
+The default bindings do not use `WASD` (camera movement) and `EC` (level change).
+You can reassign them manually and use these keys if you wish.
+
+Examples
+--------
+
+``enable gui/visible-hotkeys``
+    Just enable the default hotkeys.
+
+``overlay enable gui/visible-hotkeys.zone-overlay``
+    Display hotkeys in zone selection menu.
+    Keep in mind that this command does not enable the hotkeys,
+    so you should also use ``enable gui/visible-hotkeys``.
+
+``:lua reqscript('gui/visible-hotkeys').add('Archery Range', 'A')``
+    Use ``Shift-A`` for "Archery Range" zone painting.
+    After the script is enabled, you can modify the bindings.
+    Keep in mind that such a binding disables using ``Shift-A``
+    for moving the camera to the left when the zone choice window is visible.
+    The old hotkey will be released.
+    With the default configuration, this means ``A`` will override ``Y`` for "Archery Range",
+    and pressing ``Shift-Y`` will not trigger "Archery Range" zone paint until reassigned.
+
+``:lua reqscript('gui/visible-hotkeys').add('Gather Fruit', 'g')``
+    Use ``G`` key for "Archery Range" zone painting.
+    If the key is already in use, it will be unbound automatically from the previous action.
+    For example, by default, ``g`` is used for the "Garbage Dump" zone.
+    Thus, "Garbage Dump" loses its hotkey after being assigned ``g`` to "Gather Fruit."
+    You can leave it as is or assign a new hotkey to "Garbage Dump" in this example.
+
+Known issues
+------------
+
+The widget draws the default key bindings in the following cases:
+- The bindings are specified in ``dfhack-config/init/dfhack.init`` rather then ``dfhack-config/init/onLoad.init``
+  and the user reloads a saved game without exiting the Dwarf Fortress application.
+- The bindings are specified during the game (in the game console, ``Ctrl-Shift-P``).
+
+Workaround:
+
+Set up the key bindings for this script only in ``dfhack-config/init/onLoad.init``.
+Do not expect the overlay to display the correct information after modifying the bindings from DFHack console.

--- a/gui/visible-hotkeys.lua
+++ b/gui/visible-hotkeys.lua
@@ -4,33 +4,49 @@
 Label = require('gui.widgets.labels.label')
 OverlayWidget = require('plugins.overlay').OverlayWidget
 
-local zones = {
-    { hotkey = 'm', title = "Meeting Area", identifier = df.civzone_type.MeetingHall },
-    { hotkey = 'b', title = "Bedroom", identifier = df.civzone_type.Bedroom },
-    { hotkey = 'h', title = "Dining hall", identifier = df.civzone_type.DiningHall },
-    { hotkey = 'p', title = "Pen/Pasture", identifier = df.civzone_type.Pen },
-    { hotkey = 'P', title = "Pit/Pond", identifier = df.civzone_type.Pond },
-    { hotkey = 'r', title = "Water Source", identifier = df.civzone_type.WaterSource },
-    { hotkey = 'n', title = "Dungeon", identifier = df.civzone_type.Dungeon },
-    { hotkey = 'f', title = "Fishing", identifier = df.civzone_type.FishingArea },
-    { hotkey = 'N', title = "Sand", identifier = df.civzone_type.SandCollection },
-
-    { hotkey = 'o', title = "Office", identifier = df.civzone_type.Office },
-    { hotkey = 'y', title = "Dormitory", identifier = df.civzone_type.Dormitory },
-    { hotkey = 'B', title = "Barracks", identifier = df.civzone_type.Barracks },
-    { hotkey = 'Y', title = "Archery Range", identifier = df.civzone_type.ArcheryRange },
-    { hotkey = 'g', title = "Garbage Dump", identifier = df.civzone_type.Dump },
-    { hotkey = 'l', title = "Animal Training", identifier = df.civzone_type.AnimalTraining },
-    { hotkey = 'T', title = "Tomb", identifier = df.civzone_type.Tomb },
-    { hotkey = 'F', title = "Gather Fruit", identifier = df.civzone_type.PlantGathering },
-    { hotkey = 'L', title = "Clay", identifier = df.civzone_type.ClayCollection },
+local actions = {
+    refresh = 'refresh',
 }
+
+local zones = {
+    { hotkey = 'm', title = "Meeting Area",    identifier = df.civzone_type.MeetingHall },
+    { hotkey = 'b', title = "Bedroom",         identifier = df.civzone_type.Bedroom },
+    { hotkey = 'h', title = "Dining Hall",     identifier = df.civzone_type.DiningHall },
+    { hotkey = 'p', title = "Pen/Pasture",     identifier = df.civzone_type.Pen },
+    { hotkey = 'P', title = "Pit/Pond",        identifier = df.civzone_type.Pond },
+    { hotkey = 'r', title = "Water Source",    identifier = df.civzone_type.WaterSource },
+    { hotkey = 'n', title = "Dungeon",         identifier = df.civzone_type.Dungeon },
+    { hotkey = 'f', title = "Fishing",         identifier = df.civzone_type.FishingArea },
+    { hotkey = 'N', title = "Sand",            identifier = df.civzone_type.SandCollection },
+
+    { hotkey = 'o', title = "Office",          identifier = df.civzone_type.Office },
+    { hotkey = 'y', title = "Dormitory",       identifier = df.civzone_type.Dormitory },
+    { hotkey = 'B', title = "Barracks",        identifier = df.civzone_type.Barracks },
+    { hotkey = 'Y', title = "Archery Range",   identifier = df.civzone_type.ArcheryRange },
+    { hotkey = 'g', title = "Garbage Dump",    identifier = df.civzone_type.Dump },
+    { hotkey = 'l', title = "Animal Training", identifier = df.civzone_type.AnimalTraining },
+    { hotkey = 'T', title = "Tomb",            identifier = df.civzone_type.Tomb },
+    { hotkey = 'F', title = "Gather Fruit",    identifier = df.civzone_type.PlantGathering },
+    { hotkey = 'L', title = "Clay",            identifier = df.civzone_type.ClayCollection },
+}
+local no_hotkey_text = '*'
 
 local vertical_offset = 24
 local horizontal_offset = 7
 local item_height = 3
 local item_width = 19
 local row_count = #zones / 2
+
+local hotkey_pen = {
+    fg = COLOR_GREEN,
+    bg = COLOR_BLACK,
+    bold = true,
+}
+local empty_hotkey_pen = {
+    fg = COLOR_GRAY,
+    bg = COLOR_BLACK,
+    bold = false,
+}
 
 local function hotkey_character_to_binding(hotkey)
     if not hotkey then
@@ -50,13 +66,11 @@ local function unbind_key(zone)
     if not zone then
         qerror("An invalid zone was provided")
     end
-
-    local hotkey = zone.hotkey
-    if not hotkey then
+    if not zone.hotkey then
         return
     end
 
-    dfhack.run_command_silent(('keybinding clear %s'):format(hotkey_character_to_binding(hotkey)))
+    dfhack.run_command_silent(('keybinding clear %s'):format(hotkey_character_to_binding(zone.hotkey)))
     zone.hotkey = nil
 end
 
@@ -70,7 +84,86 @@ local function bind_key(zone)
         return
     end
 
-    dfhack.run_command_silent(('keybinding add %s "gui/visible-hotkeys %d"'):format(hotkey_character_to_binding(hotkey), zone.identifier))
+    dfhack.run_command_silent(
+            ('keybinding add %s "gui/visible-hotkeys %d"'):format(hotkey_character_to_binding(hotkey), zone.identifier)
+    )
+end
+
+local function find_zone_by_title(zone_title)
+    local current_zone
+    for _, zone in ipairs(zones) do
+        if zone.title == zone_title then
+            current_zone = zone
+            break
+        end
+    end
+    return current_zone
+end
+
+function add(zone_title, hotkey)
+    if type(zone_title) ~= "string" then
+        qerror(('Zone title must be a string, but %s was provided'):format(type(zone_title)))
+    end
+    if type(hotkey) ~= "string" then
+        qerror(('Hotkey must be a string, but %s was provided'):format(type(hotkey)))
+    end
+    if not hotkey:match("^%a$") then
+        qerror(('Hotkey must be a single small or capital letter, but "%s" was provided'):format(hotkey))
+    end
+
+    local current_zone = find_zone_by_title(zone_title)
+    if not current_zone then
+        qerror(('Cannot find zone "%s"'):format(zone_title))
+    end
+
+    -- Use a separate loop for unbinding for the case the title is not found
+    for _, zone in ipairs(zones) do
+        if zone.hotkey == hotkey then
+            unbind_key(zone)
+        end
+    end
+
+    unbind_key(current_zone)
+    current_zone.hotkey = hotkey
+    bind_key(current_zone)
+    dfhack.run_command_silent(('overlay trigger gui/visible-hotkeys.zone-overlay %s'):format(actions.refresh))
+end
+
+function clear(zone_title)
+    if type(zone_title) ~= "string" then
+        qerror(('Zone title must be a string, but %s was provided'):format(type(zone_title)))
+    end
+    local current_zone = find_zone_by_title(zone_title)
+    if not current_zone then
+        qerror(('Cannot find zone "%s"'):format(zone_title))
+    end
+
+    unbind_key(current_zone)
+    dfhack.run_command_silent(('overlay trigger gui/visible-hotkeys.zone-overlay %s'):format(actions.refresh))
+end
+
+function on_zone_key(zone_identifier)
+    local main_interface = df.global.game.main_interface
+
+    if main_interface.bottom_mode_selected ~= df.main_bottom_mode_type.ZONE then
+        qerror(('The script must be called in ZONE mode (%d), but the current mode is %d')
+                :format(df.main_bottom_mode_type.ZONE, main_interface.bottom_mode_selected))
+    end
+
+    main_interface.civzone.adding_new_type = zone_identifier
+    main_interface.bottom_mode_selected = df.main_bottom_mode_type.ZONE_PAINT
+end
+
+function start()
+    for _, zone in ipairs(zones) do
+        bind_key(zone)
+    end
+end
+
+function stop()
+    for _, zone in ipairs(zones) do
+        unbind_key(zone)
+    end
 end
 
 ZoneBindingsOverlay = defclass(ZoneBindingsOverlay, OverlayWidget)
@@ -97,16 +190,19 @@ function ZoneBindingsOverlay:init()
                 t = ((i - 1) % row_count) * item_height,
                 l = (i <= row_count) and 0 or item_width,
             },
-            text = zone.hotkey or '',
-            text_pen = {
-                fg = COLOR_GREEN,
-                bg = COLOR_BLACK,
-                bold = true,
-            },
+            text = zone.hotkey or no_hotkey_text,
+            text_pen = zone.hotkey and hotkey_pen or empty_hotkey_pen,
         }
     end
     if #key_labels > 0 then
         self:addviews(key_labels)
+    end
+end
+
+function ZoneBindingsOverlay:repaint()
+    for _, zone in ipairs(zones) do
+        self.subviews[zone.title].text_pen = zone.hotkey and hotkey_pen or empty_hotkey_pen
+        self.subviews[zone.title]:setText(zone.hotkey or no_hotkey_text)
     end
 end
 
@@ -117,58 +213,9 @@ function ZoneBindingsOverlay:render(painter)
     ZoneBindingsOverlay.super.render(self, painter)
 end
 
-function bind(zone_title, hotkey)
-    if type(hotkey) ~= "string" then
-        qerror(('Hotkey must be a string, but %s was provided'):format(type(hotkey)))
-    end
-    if not hotkey:match("^%a$") then
-        qerror(('Hotkey must be a single small or capital letter, but "%s" was provided'):format(hotkey))
-    end
-
-    local current_zone
-    for _, zone in ipairs(zones) do
-        if zone.title == zone_title then
-            current_zone = zone
-            break
-        end
-    end
-    if not current_zone then
-        qerror(('Cannot find zone "%s"'):format(zone_title))
-    end
-
-    -- Use a separate loop for unbinding for the case the title is not found
-    for _, zone in ipairs(zones) do
-        if zone.hotkey == hotkey then
-            unbind_key(zone)
-        end
-    end
-
-    unbind_key(current_zone)
-    current_zone.hotkey = hotkey
-    bind_key(current_zone)
-end
-
-function on_zone_key(zone_identifier)
-    local main_interface = df.global.game.main_interface
-
-    if main_interface.bottom_mode_selected ~= df.main_bottom_mode_type.ZONE then
-        qerror(('The script must be called in ZONE mode (%d), but the current mode is %d')
-                :format(df.main_bottom_mode_type.ZONE, main_interface.bottom_mode_selected))
-    end
-
-    main_interface.civzone.adding_new_type = zone_identifier
-    main_interface.bottom_mode_selected = df.main_bottom_mode_type.ZONE_PAINT
-end
-
-function start()
-    for _, zone in ipairs(zones) do
-        bind_key(zone)
-    end
-end
-
-function stop()
-    for _, zone in ipairs(zones) do
-        unbind_key(zone)
+function ZoneBindingsOverlay:overlay_trigger(action)
+    if action == actions.refresh then
+        self:repaint()
     end
 end
 

--- a/gui/visible-hotkeys.lua
+++ b/gui/visible-hotkeys.lua
@@ -1,0 +1,197 @@
+--@ enable = true
+--@ module = true
+
+Label = require('gui.widgets.labels.label')
+OverlayWidget = require('plugins.overlay').OverlayWidget
+
+local zones = {
+    { hotkey = 'm', title = "Meeting Area", identifier = df.civzone_type.MeetingHall },
+    { hotkey = 'b', title = "Bedroom", identifier = df.civzone_type.Bedroom },
+    { hotkey = 'h', title = "Dining hall", identifier = df.civzone_type.DiningHall },
+    { hotkey = 'p', title = "Pen/Pasture", identifier = df.civzone_type.Pen },
+    { hotkey = 'P', title = "Pit/Pond", identifier = df.civzone_type.Pond },
+    { hotkey = 'r', title = "Water Source", identifier = df.civzone_type.WaterSource },
+    { hotkey = 'n', title = "Dungeon", identifier = df.civzone_type.Dungeon },
+    { hotkey = 'f', title = "Fishing", identifier = df.civzone_type.FishingArea },
+    { hotkey = 'N', title = "Sand", identifier = df.civzone_type.SandCollection },
+
+    { hotkey = 'o', title = "Office", identifier = df.civzone_type.Office },
+    { hotkey = 'y', title = "Dormitory", identifier = df.civzone_type.Dormitory },
+    { hotkey = 'B', title = "Barracks", identifier = df.civzone_type.Barracks },
+    { hotkey = 'Y', title = "Archery Range", identifier = df.civzone_type.ArcheryRange },
+    { hotkey = 'g', title = "Garbage Dump", identifier = df.civzone_type.Dump },
+    { hotkey = 'l', title = "Animal Training", identifier = df.civzone_type.AnimalTraining },
+    { hotkey = 'T', title = "Tomb", identifier = df.civzone_type.Tomb },
+    { hotkey = 'F', title = "Gather Fruit", identifier = df.civzone_type.PlantGathering },
+    { hotkey = 'L', title = "Clay", identifier = df.civzone_type.ClayCollection },
+}
+
+local vertical_offset = 24
+local horizontal_offset = 7
+local item_height = 3
+local item_width = 19
+local row_count = #zones / 2
+
+local function hotkey_character_to_binding(hotkey)
+    if not hotkey then
+        qerror("An invalid hotkey was provided")
+    end
+
+    local hotkey_end = string.upper(hotkey)
+    local use_shift = hotkey == hotkey_end
+    if use_shift then
+        return ('Shift-%s@dwarfmode/Zone'):format(hotkey_end)
+    else
+        return ('%s@dwarfmode/Zone'):format(hotkey_end)
+    end
+end
+
+local function unbind_key(zone)
+    if not zone then
+        qerror("An invalid zone was provided")
+    end
+
+    local hotkey = zone.hotkey
+    if not hotkey then
+        return
+    end
+
+    dfhack.run_command_silent(('keybinding clear %s'):format(hotkey_character_to_binding(hotkey)))
+    zone.hotkey = nil
+end
+
+local function bind_key(zone)
+    if not zone then
+        qerror("An invalid zone was provided")
+    end
+
+    local hotkey = zone.hotkey
+    if not hotkey then
+        return
+    end
+
+    dfhack.run_command_silent(('keybinding add %s "gui/visible-hotkeys %d"'):format(hotkey_character_to_binding(hotkey), zone.identifier))
+end
+
+ZoneBindingsOverlay = defclass(ZoneBindingsOverlay, OverlayWidget)
+ZoneBindingsOverlay.ATTRS {
+    viewscreens = { 'dwarfmode/Zone' },
+    default_pos = {
+        x = horizontal_offset,
+        y = vertical_offset,
+    },
+    frame = {
+        w = item_width + 1,
+        h = row_count * item_height,
+    },
+    default_enabled = true,
+    desc = 'Display hotkeys for Zone choice menu',
+}
+
+function ZoneBindingsOverlay:init()
+    local key_labels = {}
+    for i, zone in ipairs(zones) do
+        key_labels[i] = Label {
+            view_id = zone.title,
+            frame = {
+                t = ((i - 1) % row_count) * item_height,
+                l = (i <= row_count) and 0 or item_width,
+            },
+            text = zone.hotkey or '',
+            text_pen = {
+                fg = COLOR_GREEN,
+                bg = COLOR_BLACK,
+                bold = true,
+            },
+        }
+    end
+    if #key_labels > 0 then
+        self:addviews(key_labels)
+    end
+end
+
+function ZoneBindingsOverlay:render(painter)
+    if df.global.game.main_interface.bottom_mode_selected ~= df.main_bottom_mode_type.ZONE then
+        return
+    end
+    ZoneBindingsOverlay.super.render(self, painter)
+end
+
+function bind(zone_title, hotkey)
+    if type(hotkey) ~= "string" then
+        qerror(('Hotkey must be a string, but %s was provided'):format(type(hotkey)))
+    end
+    if not hotkey:match("^%a$") then
+        qerror(('Hotkey must be a single small or capital letter, but "%s" was provided'):format(hotkey))
+    end
+
+    local current_zone
+    for _, zone in ipairs(zones) do
+        if zone.title == zone_title then
+            current_zone = zone
+            break
+        end
+    end
+    if not current_zone then
+        qerror(('Cannot find zone "%s"'):format(zone_title))
+    end
+
+    -- Use a separate loop for unbinding for the case the title is not found
+    for _, zone in ipairs(zones) do
+        if zone.hotkey == hotkey then
+            unbind_key(zone)
+        end
+    end
+
+    unbind_key(current_zone)
+    current_zone.hotkey = hotkey
+    bind_key(current_zone)
+end
+
+function on_zone_key(zone_identifier)
+    local main_interface = df.global.game.main_interface
+
+    if main_interface.bottom_mode_selected ~= df.main_bottom_mode_type.ZONE then
+        qerror(('The script must be called in ZONE mode (%d), but the current mode is %d')
+                :format(df.main_bottom_mode_type.ZONE, main_interface.bottom_mode_selected))
+    end
+
+    main_interface.civzone.adding_new_type = zone_identifier
+    main_interface.bottom_mode_selected = df.main_bottom_mode_type.ZONE_PAINT
+end
+
+function start()
+    for _, zone in ipairs(zones) do
+        bind_key(zone)
+    end
+end
+
+function stop()
+    for _, zone in ipairs(zones) do
+        unbind_key(zone)
+    end
+end
+
+OVERLAY_WIDGETS = { ['zone-overlay'] = ZoneBindingsOverlay }
+
+enabled = enabled or false
+function isEnabled()
+    return enabled
+end
+
+if dfhack_flags.enable then
+    if dfhack_flags.enable_state then
+        start()
+        enabled = true
+    else
+        stop()
+        enabled = false
+    end
+end
+
+if not dfhack_flags.module then
+    local args = { ... }
+    if #args == 1 then
+        on_zone_key(args[1])
+    end
+end


### PR DESCRIPTION
- Implement `gui/visible-hotkeys` script for zone key bindings reassignment.
- Implement `gui/visible-hotkeys.zone-overlay` to display the assigned key bindings.
- Update the documentation.