### PR TITLE
Fix #3: Sometimes, gui/visible-hotkeys.zone-overlay widget draws incorrect hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,8 @@ When you are going to create multiple temples or guilds, using mouse becomes ann
 This script allows you to remove this restriction with maximum customisation.
 
 To activate it, copy [gui/visible-hotkeys.lua] to your `hack/scripts/gui` directory
-and enable the script and overlay by adding the following lines to your `dfhack-config/init/dfhack.init`:
+and enable the overlay by adding the following lines to your `dfhack-config/init/dfhack.init`:
 ```
-# hack/scripts/gui
-
-enable gui/visible-hotkeys
 overlay enable gui/visible-hotkeys.zone-overlay
 ```
 
@@ -104,20 +101,15 @@ and uppercase letters mean holding the `Shift` button and pressing the key.
 
 #### Custom key bindings
 
-You can create your own assignments in `dfhack-config/init/onLoad.init`.
-You must use this file to avoid known issues with incorrect keys displayed in the widget.
+You can create your own assignments in `dfhack-config/init/dfhack.init`.
 If your new key binding conflicts with any other hotkey managed by the script,
 it will be unassigned first.
 
-For example, the following code assigns `Shift-A` for painting a meeting area,
-`O` (without `Shift`) for painting tomb,
-and removes bindings for bedroom zone:
+For example, the following code assigns `Shift-A` for painting a meeting area
+and `O` (`O` without `Shift`) for painting tomb:
 ```
-# dfhack-config/init/onLoad.init
-
-:lua reqscript('gui/visible-hotkeys').add('Meeting Area', 'A')
-:lua reqscript('gui/visible-hotkeys').add('Tomb', 'o')
-:lua reqscript('gui/visible-hotkeys').clear('Bedroom')
+overlay trigger gui/visible-hotkeys.zone-overlay Meeting Area A
+overlay trigger gui/visible-hotkeys.zone-overlay Tomb o
 ```
 
 By default, `o` is used for office,

--- a/README.md
+++ b/README.md
@@ -105,11 +105,13 @@ You can create your own assignments in `dfhack-config/init/dfhack.init`.
 If your new key binding conflicts with any other hotkey managed by the script,
 it will be unassigned first.
 
-For example, the following code assigns `Shift-A` for painting a meeting area
-and `O` (`O` without `Shift`) for painting tomb:
+For example, the following code assigns `Shift-A` for painting a meeting area,
+`O` (`O` without `Shift`) for painting tomb,
+and removes binding for the pit/pond zone:
 ```
-overlay trigger gui/visible-hotkeys.zone-overlay Meeting Area A
-overlay trigger gui/visible-hotkeys.zone-overlay Tomb o
+overlay trigger gui/visible-hotkeys.zone-overlay add Meeting Area A
+overlay trigger gui/visible-hotkeys.zone-overlay add Tomb o
+overlay trigger gui/visible-hotkeys.zone-overlay clear Pit/Pond
 ```
 
 By default, `o` is used for office,

--- a/docs/gui/visible-hotkeys.rst
+++ b/docs/gui/visible-hotkeys.rst
@@ -29,7 +29,13 @@ For multiple assignments, you must repeat the command with different zone titles
 
 ::
 
-    overlay trigger gui/visible-hotkeys.zone-overlay <zone title> <key>
+    overlay trigger gui/visible-hotkeys.zone-overlay add <zone title> <key>
+
+To remove a hotkey for a zone of your choice, use the following command:
+
+::
+
+    overlay trigger gui/visible-hotkeys.zone-overlay clear <zone title>
 
 Default hotkeys
 ----------------
@@ -65,7 +71,7 @@ Examples
 ``overlay enable gui/visible-hotkeys.zone-overlay``
     Display hotkeys in zone selection menu and enable the default hotkeys.
 
-``overlay trigger gui/visible-hotkeys.zone-overlay Archery Range A``
+``overlay trigger gui/visible-hotkeys.zone-overlay add Archery Range A``
     Use ``Shift-A`` for "Archery Range" zone painting.
     After the script is enabled, you can modify the bindings.
     Keep in mind that such a binding disables using ``Shift-A``
@@ -74,9 +80,16 @@ Examples
     With the default configuration, this means ``A`` will override ``Y`` for "Archery Range",
     and pressing ``Shift-Y`` will not trigger "Archery Range" zone paint until reassigned.
 
-``overlay trigger gui/visible-hotkeys.zone-overlay Gather Fruit g``
+``overlay trigger gui/visible-hotkeys.zone-overlay add Gather Fruit g``
     Use ``G`` key for "Archery Range" zone painting.
     If the key is already in use, it will be unbound automatically from the previous action.
     For example, by default, ``g`` is used for the "Garbage Dump" zone.
     Thus, "Garbage Dump" loses its hotkey after being assigned ``g`` to "Gather Fruit."
     You can leave it as is or assign a new hotkey to "Garbage Dump" in this example.
+
+``overlay trigger gui/visible-hotkeys.zone-overlay clear Pit/Pond``
+    Remove a hotkey for pit/pond zone creation.
+    It may be useful if you want to use only specific zones,
+    and keep the other bindings active for other actions when the zone window is active.
+    However, remember, the hotkeys do not have effect when you are not in zone type choice mode.
+    The bindings are only active when you can see them in the corresponding tiles.

--- a/docs/gui/visible-hotkeys.rst
+++ b/docs/gui/visible-hotkeys.rst
@@ -11,27 +11,16 @@ This script allows creating custom key bindings and shows them in the zone choic
 Usage
 -----
 
-Be careful and use the proper configuration files.
-You should enable the script and widget in ``dfhack.init``
-while key bindings reassignment should take place in ``onLoad.init``.
-This issue is due to be investigated.
+Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file.
 
-Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file
-to enable hotkeys in zone selection window:
-
-::
-
-    enable gui/visible-hotkeys
-
-Add the following lines to your ``dfhack-config/init/dfhack.init`` configuration file
-to display the hotkeys assigned via this script in zone selection window:
+Enable hotkeys in zone selection window
+and display the hotkeys assigned via this script in zone selection window:
 
 ::
 
     overlay enable gui/visible-hotkeys.zone-overlay
 
-Add the following lines to your ``dfhack-config/init/onLoad.init`` configuration file
-to modify key bindings.
+Use the following command to modify key bindings.
 The key must be a single lowercase or uppercase letter.
 An uppercase letter means using the ``Shift`` key,
 while a lowercase letter means pressing the key corresponding to the letter.
@@ -40,15 +29,7 @@ For multiple assignments, you must repeat the command with different zone titles
 
 ::
 
-    :lua reqscript('gui/visible-hotkeys').add('<zone title>', '<key>')
-
-Add the following lines to your ``dfhack-config/init/onLoad.init`` configuration file
-to remove key binding for the zone.
-It is safe to clear when no bindings are assigned.
-
-::
-
-    :lua reqscript('gui/visible-hotkeys').clear('<zone title>')
+    overlay trigger gui/visible-hotkeys.zone-overlay <zone title> <key>
 
 Default hotkeys
 ----------------
@@ -81,15 +62,10 @@ You can reassign them manually and use these keys if you wish.
 Examples
 --------
 
-``enable gui/visible-hotkeys``
-    Just enable the default hotkeys.
-
 ``overlay enable gui/visible-hotkeys.zone-overlay``
-    Display hotkeys in zone selection menu.
-    Keep in mind that this command does not enable the hotkeys,
-    so you should also use ``enable gui/visible-hotkeys``.
+    Display hotkeys in zone selection menu and enable the default hotkeys.
 
-``:lua reqscript('gui/visible-hotkeys').add('Archery Range', 'A')``
+``overlay trigger gui/visible-hotkeys.zone-overlay Archery Range A``
     Use ``Shift-A`` for "Archery Range" zone painting.
     After the script is enabled, you can modify the bindings.
     Keep in mind that such a binding disables using ``Shift-A``
@@ -98,23 +74,9 @@ Examples
     With the default configuration, this means ``A`` will override ``Y`` for "Archery Range",
     and pressing ``Shift-Y`` will not trigger "Archery Range" zone paint until reassigned.
 
-``:lua reqscript('gui/visible-hotkeys').add('Gather Fruit', 'g')``
+``overlay trigger gui/visible-hotkeys.zone-overlay Gather Fruit g``
     Use ``G`` key for "Archery Range" zone painting.
     If the key is already in use, it will be unbound automatically from the previous action.
     For example, by default, ``g`` is used for the "Garbage Dump" zone.
     Thus, "Garbage Dump" loses its hotkey after being assigned ``g`` to "Gather Fruit."
     You can leave it as is or assign a new hotkey to "Garbage Dump" in this example.
-
-Known issues
-------------
-
-The widget draws the default key bindings in the following cases:
-
-* The bindings are specified in ``dfhack-config/init/dfhack.init`` rather than ``dfhack-config/init/onLoad.init``
-  and the user reloads a saved game without exiting the Dwarf Fortress application.
-* The bindings are specified during the game (in the game console, ``Ctrl-Shift-P``).
-
-Workaround:
-
-Set up the key bindings for this script only in ``dfhack-config/init/onLoad.init``.
-Do not expect the overlay to display the correct information after modifying the bindings from the DFHack console.

--- a/gui/visible-hotkeys.lua
+++ b/gui/visible-hotkeys.lua
@@ -151,7 +151,6 @@ function ZoneBindingsOverlay:init()
     end
     self:addviews{
         Panel {
-            view_id = 'label_panel',
             visible = is_focus_zone,
             subviews = key_labels,
         },
@@ -189,18 +188,40 @@ function ZoneBindingsOverlay:add(zone_title, hotkey)
     self:change(current_zone, hotkey)
 end
 
+function ZoneBindingsOverlay:clear(zone_title, hotkey)
+    if type(zone_title) ~= "string" then
+        qerror(('Zone title must be a string, but %s was provided'):format(type(zone_title)))
+    end
+
+    local current_zone = find_zone_by_title(zone_title)
+    if not current_zone then
+        qerror(('Cannot find zone "%s"'):format(zone_title))
+    end
+
+    self:change(current_zone, nil)
+end
+
 function ZoneBindingsOverlay:overlay_trigger(...)
     local args = {...}
     if #args < 2 then
         qerror('At least three words are expected')
     end
 
-    local area_words = {}
-    for i = 1, #args - 1 do
-        area_words[i] = args[i]
+    if args[1] == "add" then
+        local zone_title_words = {}
+        for i = 2, #args - 1 do
+            zone_title_words[i - 1] = args[i]
+        end
+        local zone_title = table.concat(zone_title_words, ' ')
+        self:add(zone_title, args[#args])
+    elseif args[1] == "clear" then
+        local zone_title_words = {}
+        for i = 2, #args do
+            zone_title_words[i - 1] = args[i]
+        end
+        local zone_title = table.concat(zone_title_words, ' ')
+        self:clear(zone_title)
     end
-    local area_name = table.concat(area_words, ' ')
-    self:add(area_name, args[#args])
 end
 
 function ZoneBindingsOverlay:onInput(keys)


### PR DESCRIPTION

The script contained an enableable module and a widget.
The module and the widget held separate `zones` tables, which caused the strange behaviour.

Using `run_command` is hacky.
Replace with `onInput`.
It catches all input keys (just what we need for hotkeys)
and allows them not to pass them further:
https://docs.dfhack.org/en/stable/docs/dev/overlay-dev-guide.html#widget-example-1-adding-text-to-a-df-screen

Assign user-defined hotkeys via `overlay trigger`:
https://docs.dfhack.org/en/stable/docs/dev/overlay-dev-guide.html#overlay-widget-api

Remove the `local` statement from the `zones` initialisation because
> Values of globals persist across script runs in the same DF session.
https://docs.dfhack.org/en/stable/docs/dev/Lua%20API.html#scripts